### PR TITLE
fix: chat messages persistance

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -57,11 +57,7 @@ export class ChatClient extends IChatClient {
     this.chatInvites = new ChatInvites(this.core, this.logger);
     this.chatThreads = new ChatThreads(this.core, this.logger);
     this.chatThreadsPending = new ChatThreadsPending(this.core, this.logger);
-    this.chatMessages = new ChatMessages(
-      this.core,
-      this.chatThreads,
-      this.logger
-    );
+    this.chatMessages = new ChatMessages(this.core, this.logger);
     this.chatKeys = new ChatKeys(this.core, this.logger);
     this.history = new JsonRpcHistory(this.core, this.logger);
     this.engine = new ChatEngine(this);

--- a/src/controllers/chatMessages.ts
+++ b/src/controllers/chatMessages.ts
@@ -6,27 +6,12 @@ import {
   CHAT_MESSAGES_CONTEXT,
 } from "../constants";
 
-import { ChatClientTypes, IChatThreads } from "../types";
-let i = 0;
+import { ChatClientTypes } from "../types";
 export class ChatMessages extends Store<
   string,
-  { messages: ChatClientTypes.Message[] }
+  { messages: ChatClientTypes.Message[]; topic: string }
 > {
-  constructor(
-    public core: ICore,
-    public chatThreads: IChatThreads,
-    public logger: Logger
-  ) {
-    super(
-      core,
-      logger,
-      CHAT_MESSAGES_CONTEXT,
-      CHAT_CLIENT_STORAGE_PREFIX,
-      () => {
-        const index = i;
-        i++;
-        return chatThreads.getAll()[index].topic;
-      }
-    );
+  constructor(public core: ICore, public logger: Logger) {
+    super(core, logger, CHAT_MESSAGES_CONTEXT, CHAT_CLIENT_STORAGE_PREFIX);
   }
 }

--- a/src/controllers/engine.ts
+++ b/src/controllers/engine.ts
@@ -301,9 +301,9 @@ export class ChatEngine extends IChatEngine {
     if (this.client.chatMessages.keys.includes(topic)) {
       const current = this.client.chatMessages.get(topic);
       const messages = [...current.messages, item];
-      await this.client.chatMessages.update(topic, { messages });
+      await this.client.chatMessages.update(topic, { messages, topic });
     } else {
-      await this.client.chatMessages.set(topic, { messages: [item] });
+      await this.client.chatMessages.set(topic, { messages: [item], topic });
     }
   };
 

--- a/src/types/chatMessages.ts
+++ b/src/types/chatMessages.ts
@@ -3,5 +3,5 @@ import { ChatClientTypes } from "./client";
 
 export type IChatMessages = IStore<
   string,
-  { messages: ChatClientTypes.Message[] }
+  { messages: ChatClientTypes.Message[]; topic: string }
 >;


### PR DESCRIPTION
Passing `getKey` fx to Store to repopulate chat messages cache.

It fetches the `thread topic` in chronological order which is not bulletproof in case of persistence tampering.
Another solution might be to pass the `thread topic` in each message but that would lead to big overhead. 