### PR TITLE
fix(engine): adds missing ENGINE_RPC_OPTS config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6577,8 +6577,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7044,6 +7043,7 @@
         "@walletconnect/core": "2.0.0-rc.4",
         "@walletconnect/jsonrpc-utils": "^1.0.3",
         "@walletconnect/logger": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
         "@walletconnect/utils": "2.0.0-rc.4",
         "axios": "^0.27.2",
         "events": "^3.3.0",
@@ -7075,6 +7075,14 @@
       "version": "17.0.45",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/chat-client/node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
     }
   },
   "dependencies": {
@@ -7727,6 +7735,7 @@
         "@walletconnect/jsonrpc-types": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "^1.0.3",
         "@walletconnect/logger": "^1.0.1",
+        "@walletconnect/time": "*",
         "@walletconnect/types": "2.0.0-rc.4",
         "@walletconnect/utils": "2.0.0-rc.4",
         "aws-sdk": "^2.1169.0",
@@ -7750,6 +7759,14 @@
         "@types/node": {
           "version": "17.0.45",
           "dev": true
+        },
+        "@walletconnect/time": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+          "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+          "requires": {
+            "tslib": "1.14.1"
+          }
         }
       }
     },
@@ -11875,8 +11892,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7735,7 +7735,7 @@
         "@walletconnect/jsonrpc-types": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "^1.0.3",
         "@walletconnect/logger": "^1.0.1",
-        "@walletconnect/time": "*",
+        "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "2.0.0-rc.4",
         "@walletconnect/utils": "2.0.0-rc.4",
         "aws-sdk": "^2.1169.0",

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -31,6 +31,7 @@
     "@walletconnect/core": "2.0.0-rc.4",
     "@walletconnect/jsonrpc-utils": "^1.0.3",
     "@walletconnect/logger": "^1.0.1",
+    "@walletconnect/time": "^1.0.2",
     "@walletconnect/utils": "2.0.0-rc.4",
     "axios": "^0.27.2",
     "events": "^3.3.0",
@@ -43,6 +44,7 @@
     "@typescript-eslint/parser": "^5.16.0",
     "@walletconnect/jsonrpc-types": "^1.0.1",
     "@walletconnect/types": "2.0.0-rc.4",
+    "aws-sdk": "^2.1169.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -54,7 +56,6 @@
     "stylelint-config-recommended": "^7.0.0",
     "stylelint-config-sass-guidelines": "^9.0.1",
     "typescript": "^4.5.4",
-    "vite": "^3.2.4",
-    "aws-sdk": "^2.1169.0"
+    "vite": "^3.2.4"
   }
 }

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -4,9 +4,10 @@
   "version": "0.1.6",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
-  "main": "./dist/chat-client.cjs",
-  "module": "./dist/chat-client.mjs",
-  "types": "./dist/chat-client.d.ts",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.es.js",
+  "unpkg": "dist/index.umd.js",
+  "types": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/chat-client/src/constants/engine.ts
+++ b/packages/chat-client/src/constants/engine.ts
@@ -1,6 +1,6 @@
-export const KEYSERVER_URL = "https://keys.walletconnect.com";
+import { ONE_DAY, THIRTY_SECONDS } from "@walletconnect/time";
 
-const ONE_DAY = 86400;
+export const KEYSERVER_URL = "https://keys.walletconnect.com";
 
 interface Opts {
   tag: number;
@@ -48,13 +48,13 @@ export const ENGINE_RPC_OPTS: Record<string, { req: Opts; res: Opts }> = {
   wc_chatPing: {
     req: {
       tag: 2006,
-      prompt: true,
-      ttl: ONE_DAY,
+      prompt: false,
+      ttl: THIRTY_SECONDS,
     },
     res: {
       tag: 2007,
       prompt: false,
-      ttl: ONE_DAY,
+      ttl: THIRTY_SECONDS,
     },
   },
 };

--- a/packages/chat-client/src/constants/engine.ts
+++ b/packages/chat-client/src/constants/engine.ts
@@ -1,1 +1,60 @@
 export const KEYSERVER_URL = "https://keys.walletconnect.com";
+
+const ONE_DAY = 86400;
+
+interface Opts {
+  tag: number;
+  ttl: number;
+  prompt: boolean;
+}
+
+export const ENGINE_RPC_OPTS: Record<string, { req: Opts; res: Opts }> = {
+  wc_chatInvite: {
+    req: {
+      tag: 2000,
+      prompt: true,
+      ttl: ONE_DAY,
+    },
+    res: {
+      tag: 2001,
+      prompt: false,
+      ttl: ONE_DAY,
+    },
+  },
+  wc_chatMessage: {
+    req: {
+      tag: 2002,
+      prompt: true,
+      ttl: ONE_DAY,
+    },
+    res: {
+      tag: 2003,
+      prompt: false,
+      ttl: ONE_DAY,
+    },
+  },
+  wc_chatLeave: {
+    req: {
+      tag: 2004,
+      prompt: true,
+      ttl: ONE_DAY,
+    },
+    res: {
+      tag: 2005,
+      prompt: false,
+      ttl: ONE_DAY,
+    },
+  },
+  wc_chatPing: {
+    req: {
+      tag: 2006,
+      prompt: true,
+      ttl: ONE_DAY,
+    },
+    res: {
+      tag: 2007,
+      prompt: false,
+      ttl: ONE_DAY,
+    },
+  },
+};

--- a/packages/chat-client/src/constants/engine.ts
+++ b/packages/chat-client/src/constants/engine.ts
@@ -1,17 +1,12 @@
 import { ONE_DAY, THIRTY_SECONDS } from "@walletconnect/time";
+import { RelayerTypes } from "@walletconnect/types";
 import { JsonRpcTypes } from "../types";
 
 export const KEYSERVER_URL = "https://keys.walletconnect.com";
 
-interface Opts {
-  tag: number;
-  ttl: number;
-  prompt: boolean;
-}
-
 export const ENGINE_RPC_OPTS: Record<
   JsonRpcTypes.WcMethod,
-  { req: Opts; res: Opts }
+  { req: RelayerTypes.PublishOptions; res: RelayerTypes.PublishOptions }
 > = {
   wc_chatInvite: {
     req: {

--- a/packages/chat-client/src/constants/engine.ts
+++ b/packages/chat-client/src/constants/engine.ts
@@ -1,4 +1,5 @@
 import { ONE_DAY, THIRTY_SECONDS } from "@walletconnect/time";
+import { JsonRpcTypes } from "../types";
 
 export const KEYSERVER_URL = "https://keys.walletconnect.com";
 
@@ -8,7 +9,10 @@ interface Opts {
   prompt: boolean;
 }
 
-export const ENGINE_RPC_OPTS: Record<string, { req: Opts; res: Opts }> = {
+export const ENGINE_RPC_OPTS: Record<
+  JsonRpcTypes.WcMethod,
+  { req: Opts; res: Opts }
+> = {
   wc_chatInvite: {
     req: {
       tag: 2000,

--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -17,7 +17,7 @@ import {
 } from "@walletconnect/utils";
 import axios from "axios";
 import EventEmitter from "events";
-import { KEYSERVER_URL } from "../constants";
+import { ENGINE_RPC_OPTS, KEYSERVER_URL } from "../constants";
 
 import { IChatClient, IChatEngine } from "../types";
 import { JsonRpcTypes } from "../types/jsonrpc";
@@ -316,7 +316,8 @@ export class ChatEngine extends IChatEngine {
   ) => {
     const payload = formatJsonRpcRequest(method, params);
     const message = await this.client.core.crypto.encode(topic, payload, opts);
-    await this.client.core.relayer.publish(topic, message);
+    const rpcOpts = ENGINE_RPC_OPTS[method].req;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     this.client.history.set(topic, payload);
 
     return payload.id;
@@ -330,7 +331,9 @@ export class ChatEngine extends IChatEngine {
   ) => {
     const payload = formatJsonRpcResult(id, result);
     const message = await this.client.core.crypto.encode(topic, payload, opts);
-    await this.client.core.relayer.publish(topic, message);
+    const record = await this.client.history.get(topic, id);
+    const rpcOpts = ENGINE_RPC_OPTS[record.request.method].res;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     await this.client.history.resolve(payload);
   };
 

--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -19,8 +19,7 @@ import axios from "axios";
 import EventEmitter from "events";
 import { ENGINE_RPC_OPTS, KEYSERVER_URL } from "../constants";
 
-import { IChatClient, IChatEngine } from "../types";
-import { JsonRpcTypes } from "../types/jsonrpc";
+import { IChatClient, IChatEngine, JsonRpcTypes } from "../types";
 import { engineEvent } from "../utils/engineUtil";
 
 const SELF_INVITE_PUBLIC_KEY_NAME = "selfInvitePublicKey";

--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -344,7 +344,10 @@ export class ChatEngine extends IChatEngine {
   ) => {
     const payload = formatJsonRpcError(id, error);
     const message = await this.client.core.crypto.encode(topic, payload, opts);
-    await this.client.core.relayer.publish(topic, message);
+    const record = await this.client.history.get(topic, id);
+    const rpcOpts =
+      ENGINE_RPC_OPTS[record.request.method as JsonRpcTypes.WcMethod].res;
+    await this.client.core.relayer.publish(topic, message, rpcOpts);
     await this.client.history.resolve(payload);
   };
 

--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -331,7 +331,8 @@ export class ChatEngine extends IChatEngine {
     const payload = formatJsonRpcResult(id, result);
     const message = await this.client.core.crypto.encode(topic, payload, opts);
     const record = await this.client.history.get(topic, id);
-    const rpcOpts = ENGINE_RPC_OPTS[record.request.method].res;
+    const rpcOpts =
+      ENGINE_RPC_OPTS[record.request.method as JsonRpcTypes.WcMethod].res;
     await this.client.core.relayer.publish(topic, message, rpcOpts);
     await this.client.history.resolve(payload);
   };

--- a/packages/chat-client/src/types/index.ts
+++ b/packages/chat-client/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./chatInvites";
 export * from "./chatThreads";
 export * from "./client";
 export * from "./engine";
+export * from "./jsonrpc";


### PR DESCRIPTION
# Changes 
- Add `ttl`, `prompt` and `tag` as constants that get sent along when publishing messages