### PR TITLE
fix(client): sets up proper `ChatClientTypes.Options`, allow opts.core

### DIFF
--- a/packages/chat-client/src/client.ts
+++ b/packages/chat-client/src/client.ts
@@ -33,14 +33,14 @@ export class ChatClient extends IChatClient {
   public chatKeys: IChatClient["chatKeys"];
   public engine: IChatClient["engine"];
 
-  static async init(opts?: Record<string, any>) {
+  static async init(opts?: ChatClientTypes.Options) {
     const client = new ChatClient(opts);
     await client.initialize();
 
     return client;
   }
 
-  constructor(opts?: Record<string, any>) {
+  constructor(opts?: ChatClientTypes.Options) {
     super(opts);
 
     const logger =
@@ -52,7 +52,7 @@ export class ChatClient extends IChatClient {
             })
           );
 
-    this.core = new Core(opts);
+    this.core = opts?.core || new Core(opts);
     this.logger = generateChildLogger(logger, this.name);
     this.chatInvites = new Store(
       this.core,

--- a/packages/chat-client/src/client.ts
+++ b/packages/chat-client/src/client.ts
@@ -19,7 +19,6 @@ import { CHAT_KEYS_CONTEXT } from "./constants/chatKeys";
 import { ChatEngine } from "./controllers";
 import { ChatClientTypes, IChatClient } from "./types";
 
-// FIXME: ChatClient not reading existing chatMessages from localStorage for some reason.
 export class ChatClient extends IChatClient {
   public readonly name = "chatClient";
 

--- a/packages/chat-client/src/types/client.ts
+++ b/packages/chat-client/src/types/client.ts
@@ -1,9 +1,13 @@
-import { ICore, IStore } from "@walletconnect/types";
+import { ICore, IStore, CoreTypes } from "@walletconnect/types";
 import EventEmitter from "events";
 import { Logger } from "@walletconnect/logger";
 import { IChatEngine } from "./engine";
 
 export declare namespace ChatClientTypes {
+  interface Options extends CoreTypes.Options {
+    core?: ICore;
+  }
+
   // ---------- Data Types ----------------------------------------------- //
   interface PartialInvite {
     message: string;
@@ -95,7 +99,7 @@ export abstract class IChatClient {
   public abstract chatKeys: IStore<string, any>;
   public abstract engine: IChatEngine;
 
-  constructor(public opts?: Record<string, any>) {}
+  constructor(public opts?: ChatClientTypes.Options) {}
 
   // ---------- Public Methods ----------------------------------------------- //
 

--- a/packages/chat-client/test/client/client.spec.ts
+++ b/packages/chat-client/test/client/client.spec.ts
@@ -4,6 +4,10 @@ import ChatClient from "../../src";
 import { ChatClientTypes } from "../../src/types";
 import { disconnectSocket } from "../helpers/ws";
 
+if (!process.env.TEST_PROJECT_ID) {
+  throw new ReferenceError("TEST_PROJECT_ID env var not set");
+}
+
 const TEST_CLIENT_ACCOUNT =
   "eip155:1:0xf07A0e1454771826472AE22A212575296f309c8C";
 const TEST_PEER_ACCOUNT = "eip155:1:0xb09a878797c4406085fA7108A3b84bbed3b5881F";


### PR DESCRIPTION
## Context

* ChatClient currently doesn't handle a shared core passed via `opts.core`
* The type for init options was still generic

## Solution
* Use `opts.core` if defined
* Define proper `ChatClientTypes.Options` type
* Smaller fixes and cleanups
* Dogfooded in my web3inbox branch via canary `0.2.0-376d108`