### PR TITLE
Check for existing keys

### DIFF
--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -240,6 +240,14 @@ export class ChatEngine extends IChatEngine {
   public register: IChatEngine["register"] = async ({ account, onSign }) => {
     ZAccount.parse(account);
 
+    if (this.client.chatKeys.keys.includes(account)) {
+      const keys = this.client.chatKeys.get(account);
+      if (keys.identityKeyPub) {
+        this.currentAccount = account;
+        return keys.inviteKeyPub;
+      }
+    }
+
     const identityKey = await this.registerIdentity(account, onSign);
     await this.registerInvite(account, false);
 


### PR DESCRIPTION
# Changes
If `register` is called when the account is already registered, do not attempt to re-register