### PR TITLE
Fix typo in client opts

### DIFF
--- a/packages/chat-client/src/client.ts
+++ b/packages/chat-client/src/client.ts
@@ -53,7 +53,7 @@ export class ChatClient extends IChatClient {
               level: opts?.logger || "error",
             })
           );
-    this.keyserverUrl = opts?.keyseverUrl ?? KEYSERVER_URL;
+    this.keyserverUrl = opts?.keyserverUrl ?? KEYSERVER_URL;
 
     this.core = opts?.core || new Core(opts);
     this.logger = generateChildLogger(logger, this.name);

--- a/packages/chat-client/src/types/client.ts
+++ b/packages/chat-client/src/types/client.ts
@@ -72,7 +72,7 @@ export const ZChatKey = z.object({
 export declare namespace ChatClientTypes {
   interface Options extends CoreTypes.Options {
     core?: ICore;
-    keyseverUrl?: string;
+    keyserverUrl?: string;
   }
 
   // ---------- Data Types ----------------------------------------------- //


### PR DESCRIPTION
- `keyseverUrl` -> `keyserverUrl`