### PR TITLE
Fix identity key issues

### DIFF
--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -68,37 +68,26 @@ export class ChatEngine extends IChatEngine {
     }
   };
 
+  // Needs to be called after identity key has been created.
+  private generateAndStoreInviteKey = async (accountId: string) => {
+    const pubKeyHex = await this.client.core.crypto.generateKeyPair();
+    const privKeyHex = this.client.core.crypto.keychain.get(pubKeyHex);
+    this.client.chatKeys.update(accountId, {
+      inviteKeyPriv: privKeyHex,
+      inviteKeyPub: pubKeyHex,
+    });
+    return pubKeyHex;
+  };
+
   // type invite has to be called after type identity
-  private generateAndStoreKeyserverKeys = async (
-    accountId: string,
-    type: "invite" | "identity"
-  ) => {
-    if (type === "invite") {
-      const pubKeyHex = await this.client.core.crypto.generateKeyPair();
-      const privKeyHex = this.client.core.crypto.keychain.get(pubKeyHex);
-      this.client.chatKeys.update(accountId, {
-        inviteKeyPriv: privKeyHex,
-        inviteKeyPub: pubKeyHex,
-      });
-      return pubKeyHex;
-    } else if (type === "identity") {
-      const privateKey = ed25519.utils.randomPrivateKey();
-      const publicKey = await ed25519.getPublicKey(privateKey);
+  private generateIdentityKey = async () => {
+    const privateKey = ed25519.utils.randomPrivateKey();
+    const publicKey = await ed25519.getPublicKey(privateKey);
 
-      const pubKeyHex = ed25519.utils.bytesToHex(publicKey).toLowerCase();
-      const privKeyHex = ed25519.utils.bytesToHex(privateKey).toLowerCase();
-      this.client.core.crypto.keychain.set(pubKeyHex, privKeyHex);
-      this.client.chatKeys.set(accountId, {
-        identityKeyPriv: privKeyHex,
-        identityKeyPub: pubKeyHex,
-        accountId,
-        inviteKeyPriv: "",
-        inviteKeyPub: "",
-      });
-      return pubKeyHex;
-    }
-
-    throw new Error("Invalid type provided");
+    const pubKeyHex = ed25519.utils.bytesToHex(publicKey).toLowerCase();
+    const privKeyHex = ed25519.utils.bytesToHex(privateKey).toLowerCase();
+    this.client.core.crypto.keychain.set(pubKeyHex, privKeyHex);
+    return [pubKeyHex, privKeyHex];
   };
 
   private generateIdAuth = (accountId: string, payload: InviteKeyClaims) => {
@@ -116,10 +105,7 @@ export class ChatEngine extends IChatEngine {
       const storedKeyPair = this.client.chatKeys.get(accountId);
       return storedKeyPair.identityKeyPub;
     } catch {
-      const pubKeyHex = await this.generateAndStoreKeyserverKeys(
-        accountId,
-        "identity"
-      );
+      const [pubKeyHex, privKeyHex] = await this.generateIdentityKey();
       const didKey = encodeEd25519Key(pubKeyHex);
 
       const cacao: Cacao = {
@@ -145,6 +131,16 @@ export class ChatEngine extends IChatEngine {
       const cacaoMessage = formatMessage(cacao.p, composeDidPkh(accountId));
 
       const signature = await onSign(cacaoMessage);
+
+      // Storing keys after signature creation to prevent having false statement
+      // Eg, onSign failing / never resolving but having identity keys stored.
+      this.client.chatKeys.set(accountId, {
+        identityKeyPriv: privKeyHex,
+        identityKeyPub: pubKeyHex,
+        accountId,
+        inviteKeyPriv: "",
+        inviteKeyPub: "",
+      });
 
       const url = `${this.keyserverUrl}/identity`;
 
@@ -172,10 +168,7 @@ export class ChatEngine extends IChatEngine {
 
       throw new Error("Invite key not registered");
     } catch {
-      const pubKeyHex = await this.generateAndStoreKeyserverKeys(
-        accountId,
-        "invite"
-      );
+      const pubKeyHex = await this.generateAndStoreInviteKey(accountId);
 
       const { identityKeyPub } = this.client.chatKeys.get(accountId);
 
@@ -241,14 +234,6 @@ export class ChatEngine extends IChatEngine {
   public register: IChatEngine["register"] = async ({ account, onSign }) => {
     ZAccount.parse(account);
 
-    if (this.client.chatKeys.keys.includes(account)) {
-      const keys = this.client.chatKeys.get(account);
-      if (keys.identityKeyPub) {
-        this.currentAccount = account;
-        return keys.inviteKeyPub;
-      }
-    }
-
     const identityKey = await this.registerIdentity(account, onSign);
     await this.registerInvite(account, false);
 
@@ -262,7 +247,6 @@ export class ChatEngine extends IChatEngine {
   public resolveIdentity: IChatEngine["resolveIdentity"] = async ({
     publicKey,
   }) => {
-    console.log("RESOLVEIDENTITY >>", { publicKey });
     const url = `${this.keyserverUrl}/identity?publicKey=${
       publicKey.split(":")[2]
     }`;
@@ -272,14 +256,12 @@ export class ChatEngine extends IChatEngine {
       return data.value.cacao;
     } catch (e: any) {
       console.error(e.toJSON());
-      throw new Error("Failed");
+      throw new Error("Failed to resolve identity key");
     }
   };
 
   public resolveInvite: IChatEngine["resolveInvite"] = async ({ account }) => {
     const url = `${this.keyserverUrl}/invite?account=${account}`;
-
-    console.log("Fetching invite acc", url);
 
     try {
       const { data } = await axios.get<{ value: { inviteKey: string } }>(url);

--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -79,7 +79,6 @@ export class ChatEngine extends IChatEngine {
     return pubKeyHex;
   };
 
-  // type invite has to be called after type identity
   private generateIdentityKey = async () => {
     const privateKey = ed25519.utils.randomPrivateKey();
     const publicKey = await ed25519.getPublicKey(privateKey);

--- a/packages/chat-client/test/client/client.spec.ts
+++ b/packages/chat-client/test/client/client.spec.ts
@@ -406,4 +406,28 @@ describe("ChatClient", () => {
       expect(client.getMessages({ topic })).toEqual(mockChatMessages);
     });
   });
+
+  describe("Multi account storage", () => {
+    it("Can register different accounts", async () => {
+      const walletSelf1 = Wallet.createRandom();
+      const walletSelf2 = Wallet.createRandom();
+
+      const identityKey1 = await client.register({
+        account: composeChainAddress(walletSelf1.address),
+        onSign: (message) => walletSelf1.signMessage(message),
+      });
+
+      const identityKey2 = await client.register({
+        account: composeChainAddress(walletSelf2.address),
+        onSign: (message) => walletSelf2.signMessage(message),
+      });
+
+      expect(identityKey1).toBeTruthy();
+      expect(identityKey2).toBeTruthy();
+
+      console.table({ identityKey1, identityKey2 });
+
+      expect(identityKey1).to.not.eq(identityKey2);
+    });
+  });
 });


### PR DESCRIPTION
# Changes
- Only store identity key after `onSign` successfully resolves
- Separated out invite key and identity key creation functions
- Add unit test for multi account