### PR TITLE
Match chat_invite_accepted to specs

### DIFF
--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -783,11 +783,8 @@ export class ChatEngine extends IChatEngine {
 
       this.client.emit("chat_invite_accepted", {
         id: payload.id,
-        topic: topic,
-        params: {
-          invite: this.client.chatSentInvites.get(topic),
-          topic: chatThreadTopic,
-        },
+        topic,
+        invite: this.client.chatSentInvites.get(topic),
       });
     } else if (isJsonRpcError(payload)) {
       this.client.logger.error(payload.error);
@@ -806,11 +803,9 @@ export class ChatEngine extends IChatEngine {
     });
 
     this.client.emit("chat_invite_rejected", {
-      id: id,
-      topic: topic,
-      params: {
-        invite: this.client.chatSentInvites.get(topic),
-      },
+      id,
+      topic,
+      invite: this.client.chatSentInvites.get(topic),
     });
   };
 

--- a/packages/chat-client/src/types/client.ts
+++ b/packages/chat-client/src/types/client.ts
@@ -115,8 +115,8 @@ export declare namespace ChatClientTypes {
     chat_message: BaseEventArgs<Message>;
     chat_ping: Omit<BaseEventArgs, "params">;
     chat_left: Omit<BaseEventArgs, "params">;
-    chat_invite_accepted: BaseEventArgs<{ invite: SentInvite; topic: string }>;
-    chat_invite_rejected: BaseEventArgs<{ invite: SentInvite }>;
+    chat_invite_accepted: { invite: SentInvite; topic: string; id: number };
+    chat_invite_rejected: { invite: SentInvite; id: number; topic: string };
   }
 }
 


### PR DESCRIPTION
# Changes
- Move `invite` up in depth for `chat_invite_accepted` and `chat_invite_rejected` as specified in specs

