### PR TITLE
Chore/match unregister act spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8348,7 +8348,7 @@
     },
     "packages/chat-client": {
       "name": "@walletconnect/chat-client",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/core": "^2.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,92 +1645,17 @@
       }
     },
     "node_modules/@walletconnect/sync-client": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.6.tgz",
-      "integrity": "sha512-79Viicx2/fOZCVihkO6zdzWRZzuA+C+HwEovIaqVbyyZ2VCaVyBGfyYDb2hgNpXbHptyH1y/hpUVgkmTcSxHmg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.7.tgz",
+      "integrity": "sha512-tCcP68sDw6y2UGzEbFXxuf/uzkUIlVBfhFaEgWFo1EONqhiofCSmHabJaFpYk+0P6dYWjmgba0E1GPVh8TUbHQ==",
       "dependencies": {
         "@ethersproject/wallet": "^5.7.0",
-        "@walletconnect/core": "2.4.4",
+        "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/types": "2.4.4",
-        "@walletconnect/utils": "2.4.4",
+        "@walletconnect/utils": "^2.5.2",
         "bip32": "2.0.6",
         "bip39": "^3.0.4",
         "uint8arrays": "^4.0.3"
-      }
-    },
-    "node_modules/@walletconnect/sync-client/node_modules/@walletconnect/core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-tdMmPNGgpTrk95hG8H5V6Du59HA4e3tVdvGngZjcja6VnmkfZdW4fGCWaJWyKYkrQQknDug4dH47/HZ6cAxj/g==",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-provider": "^1.0.6",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
-        "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/relay-api": "^1.0.7",
-        "@walletconnect/relay-auth": "^1.0.4",
-        "@walletconnect/safe-json": "^1.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.4.4",
-        "@walletconnect/utils": "2.4.4",
-        "events": "^3.3.0",
-        "lodash.isequal": "4.5.0",
-        "pino": "7.11.0",
-        "uint8arrays": "3.1.0"
-      }
-    },
-    "node_modules/@walletconnect/sync-client/node_modules/@walletconnect/core/node_modules/uint8arrays": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
-    "node_modules/@walletconnect/sync-client/node_modules/@walletconnect/types": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.4.4.tgz",
-      "integrity": "sha512-4XndBOlB0qbhaJvzcBZCfR69rfU5rV0U5b3YbJ1AmtxcJSJAIg68WDP7o4BE4w1LHzdsEWvbXHRYL+KsA+uG3w==",
-      "dependencies": {
-        "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "1.2.0",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
-        "@walletconnect/keyvaluestorage": "^1.0.2",
-        "@walletconnect/logger": "^2.0.1",
-        "events": "^3.3.0"
-      }
-    },
-    "node_modules/@walletconnect/sync-client/node_modules/@walletconnect/utils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.4.4.tgz",
-      "integrity": "sha512-PM4biwrvi5OwXIroLHDxtCOXlvZGCGNvbYS0Jkb6ZmP1EbGjVz1xA1hnp/lC3eGFQArSyvS7EHD6XQQpymZ2jA==",
-      "dependencies": {
-        "@stablelib/chacha20poly1305": "1.0.1",
-        "@stablelib/hkdf": "1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/sha256": "1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/relay-api": "^1.0.7",
-        "@walletconnect/safe-json": "^1.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.4.4",
-        "@walletconnect/window-getters": "^1.0.1",
-        "@walletconnect/window-metadata": "^1.0.1",
-        "detect-browser": "5.3.0",
-        "query-string": "7.1.1",
-        "uint8arrays": "3.1.0"
-      }
-    },
-    "node_modules/@walletconnect/sync-client/node_modules/@walletconnect/utils/node_modules/uint8arrays": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-      "dependencies": {
-        "multiformats": "^9.4.2"
       }
     },
     "node_modules/@walletconnect/sync-client/node_modules/uint8arrays": {
@@ -8354,7 +8279,7 @@
         "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sync-client": "^0.2.6",
+        "@walletconnect/sync-client": "^0.2.7",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/utils": "^2.5.2",
         "axios": "^0.27.2",
@@ -9588,98 +9513,19 @@
       }
     },
     "@walletconnect/sync-client": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.6.tgz",
-      "integrity": "sha512-79Viicx2/fOZCVihkO6zdzWRZzuA+C+HwEovIaqVbyyZ2VCaVyBGfyYDb2hgNpXbHptyH1y/hpUVgkmTcSxHmg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.7.tgz",
+      "integrity": "sha512-tCcP68sDw6y2UGzEbFXxuf/uzkUIlVBfhFaEgWFo1EONqhiofCSmHabJaFpYk+0P6dYWjmgba0E1GPVh8TUbHQ==",
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
-        "@walletconnect/core": "2.4.4",
+        "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
-        "@walletconnect/types": "2.4.4",
-        "@walletconnect/utils": "2.4.4",
+        "@walletconnect/utils": "^2.5.2",
         "bip32": "2.0.6",
         "bip39": "^3.0.4",
         "uint8arrays": "^4.0.3"
       },
       "dependencies": {
-        "@walletconnect/core": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.4.4.tgz",
-          "integrity": "sha512-tdMmPNGgpTrk95hG8H5V6Du59HA4e3tVdvGngZjcja6VnmkfZdW4fGCWaJWyKYkrQQknDug4dH47/HZ6cAxj/g==",
-          "requires": {
-            "@walletconnect/heartbeat": "1.2.0",
-            "@walletconnect/jsonrpc-provider": "^1.0.6",
-            "@walletconnect/jsonrpc-utils": "^1.0.4",
-            "@walletconnect/jsonrpc-ws-connection": "^1.0.7",
-            "@walletconnect/keyvaluestorage": "^1.0.2",
-            "@walletconnect/logger": "^2.0.1",
-            "@walletconnect/relay-api": "^1.0.7",
-            "@walletconnect/relay-auth": "^1.0.4",
-            "@walletconnect/safe-json": "^1.0.1",
-            "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.4.4",
-            "@walletconnect/utils": "2.4.4",
-            "events": "^3.3.0",
-            "lodash.isequal": "4.5.0",
-            "pino": "7.11.0",
-            "uint8arrays": "3.1.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-              "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
-        "@walletconnect/types": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.4.4.tgz",
-          "integrity": "sha512-4XndBOlB0qbhaJvzcBZCfR69rfU5rV0U5b3YbJ1AmtxcJSJAIg68WDP7o4BE4w1LHzdsEWvbXHRYL+KsA+uG3w==",
-          "requires": {
-            "@walletconnect/events": "^1.0.1",
-            "@walletconnect/heartbeat": "1.2.0",
-            "@walletconnect/jsonrpc-types": "^1.0.2",
-            "@walletconnect/keyvaluestorage": "^1.0.2",
-            "@walletconnect/logger": "^2.0.1",
-            "events": "^3.3.0"
-          }
-        },
-        "@walletconnect/utils": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.4.4.tgz",
-          "integrity": "sha512-PM4biwrvi5OwXIroLHDxtCOXlvZGCGNvbYS0Jkb6ZmP1EbGjVz1xA1hnp/lC3eGFQArSyvS7EHD6XQQpymZ2jA==",
-          "requires": {
-            "@stablelib/chacha20poly1305": "1.0.1",
-            "@stablelib/hkdf": "1.0.1",
-            "@stablelib/random": "^1.0.2",
-            "@stablelib/sha256": "1.0.1",
-            "@stablelib/x25519": "^1.0.3",
-            "@walletconnect/jsonrpc-utils": "^1.0.4",
-            "@walletconnect/relay-api": "^1.0.7",
-            "@walletconnect/safe-json": "^1.0.1",
-            "@walletconnect/time": "^1.0.2",
-            "@walletconnect/types": "2.4.4",
-            "@walletconnect/window-getters": "^1.0.1",
-            "@walletconnect/window-metadata": "^1.0.1",
-            "detect-browser": "5.3.0",
-            "query-string": "7.1.1",
-            "uint8arrays": "3.1.0"
-          },
-          "dependencies": {
-            "uint8arrays": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-              "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-              "requires": {
-                "multiformats": "^9.4.2"
-              }
-            }
-          }
-        },
         "uint8arrays": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@walletconnect/sync-client": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.7.tgz",
-      "integrity": "sha512-tCcP68sDw6y2UGzEbFXxuf/uzkUIlVBfhFaEgWFo1EONqhiofCSmHabJaFpYk+0P6dYWjmgba0E1GPVh8TUbHQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.3.0.tgz",
+      "integrity": "sha512-sw+5jl1v4YrVPpDiOc+psJI8dVG+p3TwDteSInl9tJFmrcCdB0FNbbNmbT048zHODPu0K9Rntr14Ng1WaDWnTA==",
       "dependencies": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/core": "^2.5.2",
@@ -8388,7 +8388,7 @@
         "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sync-client": "^0.2.7",
+        "@walletconnect/sync-client": "^0.3.0",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/utils": "^2.5.2",
         "axios": "^0.27.2",
@@ -9446,12 +9446,12 @@
         "@types/node": "^17.0.23",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "@walletconnect/cacao": "*",
+        "@walletconnect/cacao": "^1.0.1",
         "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sync-client": "^0.2.7",
+        "@walletconnect/sync-client": "0.3.0",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "^2.5.2",
         "@walletconnect/utils": "^2.5.2",
@@ -9633,9 +9633,9 @@
       }
     },
     "@walletconnect/sync-client": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.2.7.tgz",
-      "integrity": "sha512-tCcP68sDw6y2UGzEbFXxuf/uzkUIlVBfhFaEgWFo1EONqhiofCSmHabJaFpYk+0P6dYWjmgba0E1GPVh8TUbHQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.3.0.tgz",
+      "integrity": "sha512-sw+5jl1v4YrVPpDiOc+psJI8dVG+p3TwDteSInl9tJFmrcCdB0FNbbNmbT048zHODPu0K9Rntr14Ng1WaDWnTA==",
       "requires": {
         "@ethersproject/wallet": "^5.7.0",
         "@walletconnect/core": "^2.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/chat-client"
       ],
+      "dependencies": {
+        "@walletconnect/cacao": "^1.0.1"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-json": "^6.0.0",
@@ -1486,6 +1489,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@walletconnect/cacao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/cacao/-/cacao-1.0.1.tgz",
+      "integrity": "sha512-UcRQEofUSjpK5QMXUvc3V7IPdSWKheSrZb1Fb5PYqhVj1A70t0wZgRszoJ54OAQl9EAv50Sbl8KWu3IDMboZxA==",
+      "dependencies": {
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "isomorphic-unfetch": "^4.0.2"
+      }
+    },
     "node_modules/@walletconnect/chat-client": {
       "resolved": "packages/chat-client",
       "link": true
@@ -2594,6 +2607,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -3956,6 +3977,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4071,6 +4114,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -4914,6 +4968,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
+      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
+      "dependencies": {
+        "node-fetch": "^3.2.0",
+        "unfetch": "^5.0.0"
+      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -5850,6 +5913,41 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-package-data": {
@@ -7775,6 +7873,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -7964,6 +8067,14 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -9317,6 +9428,16 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@walletconnect/cacao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/cacao/-/cacao-1.0.1.tgz",
+      "integrity": "sha512-UcRQEofUSjpK5QMXUvc3V7IPdSWKheSrZb1Fb5PYqhVj1A70t0wZgRszoJ54OAQl9EAv50Sbl8KWu3IDMboZxA==",
+      "requires": {
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "isomorphic-unfetch": "^4.0.2"
+      }
+    },
     "@walletconnect/chat-client": {
       "version": "file:packages/chat-client",
       "requires": {
@@ -9331,7 +9452,7 @@
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sync-client": "^0.2.6",
+        "@walletconnect/sync-client": "^0.2.7",
         "@walletconnect/time": "^1.0.2",
         "@walletconnect/types": "^2.5.2",
         "@walletconnect/utils": "^2.5.2",
@@ -10263,6 +10384,11 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -11173,6 +11299,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11253,6 +11388,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs.realpath": {
@@ -11833,6 +11976,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "isomorphic-unfetch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-4.0.2.tgz",
+      "integrity": "sha512-1Yd+CF/7al18/N2BDbsLBcp6RO3tucSW+jcLq24dqdX5MNbCNTw1z4BsGsp4zNmjr/Izm2cs/cEqZPp4kvWSCA==",
+      "requires": {
+        "node-fetch": "^3.2.0",
+        "unfetch": "^5.0.0"
+      }
     },
     "joycon": {
       "version": "3.1.1",
@@ -12559,6 +12711,21 @@
             }
           }
         }
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "normalize-package-data": {
@@ -13955,6 +14122,11 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "unfetch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-5.0.0.tgz",
+      "integrity": "sha512-3xM2c89siXg0nHvlmYsQ2zkLASvVMBisZm5lF3gFDqfF2xonNStDJyMpvaOBe0a1Edxmqrf2E0HBdmy9QyZaeg=="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -14067,6 +14239,11 @@
         "tinyspy": "^1.0.0",
         "vite": "^2.9.12 || ^3.0.0-0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "workspaces": [
         "packages/chat-client"
       ],
-      "dependencies": {
-        "@walletconnect/cacao": "^1.0.1"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
         "@rollup/plugin-json": "^6.0.0",
@@ -8387,6 +8384,7 @@
       "version": "0.5.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
+        "@walletconnect/cacao": "^1.0.1",
         "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/logger": "^2.0.1",
@@ -9448,6 +9446,7 @@
         "@types/node": "^17.0.23",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
+        "@walletconnect/cacao": "*",
         "@walletconnect/core": "^2.5.2",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "sinon": "14.0.0",
     "typescript": "4.7.4",
     "vitest": "0.19.0"
+  },
+  "dependencies": {
+    "@walletconnect/cacao": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,5 @@
     "sinon": "14.0.0",
     "typescript": "4.7.4",
     "vitest": "0.19.0"
-  },
-  "dependencies": {
-    "@walletconnect/cacao": "^1.0.1"
   }
 }

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/chat-client",
   "description": "Chat Client for WalletConnect Protocol",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-monorepo/",
   "main": "dist/index.cjs.js",

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/core": "^2.5.2",
     "@walletconnect/jsonrpc-utils": "^1.0.6",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sync-client": "^0.2.7",
+    "@walletconnect/sync-client": "^0.3.0",
     "@walletconnect/time": "^1.0.2",
     "@walletconnect/utils": "^2.5.2",
     "axios": "^0.27.2",

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -33,7 +33,7 @@
     "@walletconnect/core": "^2.5.2",
     "@walletconnect/jsonrpc-utils": "^1.0.6",
     "@walletconnect/logger": "^2.0.1",
-    "@walletconnect/sync-client": "^0.2.6",
+    "@walletconnect/sync-client": "^0.2.7",
     "@walletconnect/time": "^1.0.2",
     "@walletconnect/utils": "^2.5.2",
     "axios": "^0.27.2",

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@noble/ed25519": "^1.7.1",
+    "@walletconnect/cacao": "^1.0.1",
     "@walletconnect/core": "^2.5.2",
     "@walletconnect/jsonrpc-utils": "^1.0.6",
     "@walletconnect/logger": "^2.0.1",

--- a/packages/chat-client/src/client.ts
+++ b/packages/chat-client/src/client.ts
@@ -25,6 +25,8 @@ export class ChatClient extends IChatClient {
   public readonly name = "chatClient";
   public readonly keyserverUrl;
 
+  public projectId: string;
+
   public core: ICore;
   public syncClient: ISyncClient | undefined;
   public events = new EventEmitter();
@@ -37,15 +39,17 @@ export class ChatClient extends IChatClient {
   public chatKeys: IChatClient["chatKeys"];
   public engine: IChatClient["engine"];
 
-  static async init(opts?: ChatClientTypes.Options) {
+  static async init(opts: ChatClientTypes.Options) {
     const client = new ChatClient(opts);
     await client.initialize();
 
     return client;
   }
 
-  constructor(opts?: ChatClientTypes.Options) {
+  constructor(opts: ChatClientTypes.Options) {
     super(opts);
+
+    this.projectId = opts.projectId;
 
     const logger =
       typeof opts?.logger !== "undefined" && typeof opts?.logger !== "string"
@@ -213,8 +217,31 @@ export class ChatClient extends IChatClient {
     }
   };
 
-  public addContact: IChatClient["addContact"] = ({ account, publicKey }) => {
-    this.chatContacts.set(account, { accountId: account, publicKey });
+  public goPublic: IChatClient["goPublic"] = async ({ account }) => {
+    try {
+      return this.engine.goPublic({ account });
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  };
+
+  public goPrivate: IChatClient["goPrivate"] = async ({ account }) => {
+    try {
+      return this.engine.goPrivate({ account });
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  };
+
+  public unregister: IChatClient["unregister"] = async ({ account }) => {
+    try {
+      return this.engine.unregisterIdentity({ account });
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
   };
 
   // ---------- Events ----------------------------------------------- //

--- a/packages/chat-client/src/types/client.ts
+++ b/packages/chat-client/src/types/client.ts
@@ -75,6 +75,7 @@ export declare namespace ChatClientTypes {
   interface Options extends CoreTypes.Options {
     core?: ICore;
     keyserverUrl?: string;
+    projectId: string;
   }
 
   // ---------- Data Types ----------------------------------------------- //
@@ -152,6 +153,8 @@ export abstract class IChatClient {
   public abstract chatKeys: IStore<string, IdentityKeychain>;
   public abstract engine: IChatEngine;
 
+  public abstract projectId: string;
+
   constructor(public opts?: ChatClientTypes.Options) {}
 
   // ---------- Public Methods ----------------------------------------------- //
@@ -209,10 +212,11 @@ export abstract class IChatClient {
     topic: string;
   }): ChatClientTypes.Message[];
 
-  public abstract addContact(params: {
-    account: string;
-    publicKey: string;
-  }): void;
+  public abstract goPublic(params: { account: string }): Promise<string>;
+
+  public abstract goPrivate(params: { account: string }): Promise<void>;
+
+  public abstract unregister(params: { account: string }): Promise<void>;
 
   // ---------- Event Handlers ----------------------------------------------- //
 

--- a/packages/chat-client/src/types/engine.ts
+++ b/packages/chat-client/src/types/engine.ts
@@ -38,6 +38,10 @@ export abstract class IChatEngine {
 
   public abstract resolveInvite(params: { account: string }): Promise<string>;
 
+  public abstract unregisterIdentity(params: {
+    account: string;
+  }): Promise<void>;
+
   public abstract invite(params: ChatClientTypes.Invite): Promise<number>;
 
   public abstract accept(params: { id: number }): Promise<string>;

--- a/packages/chat-client/src/utils/jwtAuth.ts
+++ b/packages/chat-client/src/utils/jwtAuth.ts
@@ -10,13 +10,14 @@ interface JwtHeader {
 
 export interface InviteKeyClaims {
   iss: string;
-  sub: string;
+  act: string;
+  iat: number;
+  exp: number;
+  sub?: string;
   aud?: string;
   ksu?: string;
   pkh?: string;
   pke?: string;
-  iat: number;
-  exp: number;
 }
 
 export const DAY_IN_MS = 86400 * 1000;


### PR DESCRIPTION
# Changes
- Update `sync-client`
- Update `@walletconnect/cacao`
- Make passing `projectId` mandatory in chat client init
- Add `act` field to all key claims
- Verify cacao from sent messages
- Add `goPrivate`, `goPublic` and `unregister` in client as per specs
- Add unit test for `unregisterIdentity`

# Specs
All this is per the following specs:
- [Chat Client API](https://docs.walletconnect.com/2.0/specs/clients/chat/client-api)
- [Unregister spec](https://docs.walletconnect.com/2.0/specs/servers/keys/identity-keys#unregistration)
- [Act spec](https://docs.walletconnect.com/2.0/specs/clients/chat/chat-authentication) 

# Note
The bump to `0.5.0` was already published but not merged into main