### PR TITLE
Throw error if already invited

### DIFF
--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -228,10 +228,30 @@ export class ChatEngine extends IChatEngine {
   };
 
   public invite: IChatEngine["invite"] = async (invite) => {
-    // resolve peer account pubKey X
-
     const { inviteePublicKey, inviterAccount, inviteeAccount, message } =
       ZInvite.parse(invite);
+
+    const alreadyInvited = Boolean(
+      this.client.chatSentInvites
+        .getAll()
+        .find((inv) => inv.inviteeAccount === invite.inviteeAccount)
+    );
+
+    const alreadyHasThread = Boolean(
+      this.client.chatThreads
+        .getAll()
+        .find((thread) => thread.peerAccount === invite.inviteeAccount)
+    );
+
+    if (alreadyHasThread) {
+      throw new Error(
+        `Address ${invite.inviteeAccount} already has established thread`
+      );
+    }
+
+    if (alreadyInvited) {
+      throw new Error(`Address ${invite.inviteeAccount} already invited`);
+    }
 
     // generate a keyPair Y to encrypt the invite with derived DH symKey I.
     const pubkeyY = await this.client.core.crypto.generateKeyPair();


### PR DESCRIPTION
# Changes
- If a thread already established, `invite` will throw an error when inviting an existing address
- If an invite has already been sent, `invite` will throw an error when inviting an address that has been invited