### PR TITLE
fix: encode inviter account as didPkh in Invite Approval Payload

### DIFF
--- a/packages/chat-client/src/controllers/engine.ts
+++ b/packages/chat-client/src/controllers/engine.ts
@@ -380,7 +380,7 @@ export class ChatEngine extends IChatEngine {
       exp: jwtExp(iat),
       iss: encodeEd25519Key(identityKeyPub),
       sub: encodeX25519Key(publicKeyZ),
-      aud: invite.inviterAccount,
+      aud: composeDidPkh(invite.inviterAccount),
       ksu: this.keyserverUrl,
       act: "invite_approval",
     };


### PR DESCRIPTION
Artur noticed that aud was not encoded as didPkh as per specs: https://docs.walletconnect.com/2.0/specs/clients/chat/chat-authentication#invite-approvals